### PR TITLE
Updating Dockerfiles with clang-format version 8.

### DIFF
--- a/dockerfiles/Dockerfile.sdl_build.u18.04
+++ b/dockerfiles/Dockerfile.sdl_build.u18.04
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get -q -y install qt5-default libqt5websockets5-dev li
 
 # SDL build dependencies
 RUN apt-get update && apt-get -q -y install cmake libssl-dev libusb-1.0-0-dev \
-  libudev-dev libsqlite3-dev libbluetooth-dev clang-format-6.0
+  libudev-dev libsqlite3-dev libbluetooth-dev clang-format-8
 
 RUN apt-get update && apt-get -q -y install python3-pip python3-setuptools
 

--- a/dockerfiles/Dockerfile.sdl_build.u18.04
+++ b/dockerfiles/Dockerfile.sdl_build.u18.04
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get -q -y install qt5-default libqt5websockets5-dev li
 
 # SDL build dependencies
 RUN apt-get update && apt-get -q -y install cmake libssl-dev libusb-1.0-0-dev \
-  libudev-dev libsqlite3-dev libbluetooth-dev clang-format-6.0
+  libudev-dev libsqlite3-dev libbluetooth-dev clang-format-6.0 clang-format-8
 
 RUN apt-get update && apt-get -q -y install python3-pip python3-setuptools
 

--- a/dockerfiles/Dockerfile.sdl_build.u18.04.cppcheck
+++ b/dockerfiles/Dockerfile.sdl_build.u18.04.cppcheck
@@ -3,7 +3,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt update && apt install -yq \
     automake \
     ccache \
-    clang-format-6.0 \
+    clang-format-8 \
     g++ \
     gdb \
     lcov \

--- a/dockerfiles/Dockerfile.sdl_build.u18.04.cppcheck
+++ b/dockerfiles/Dockerfile.sdl_build.u18.04.cppcheck
@@ -4,6 +4,7 @@ RUN apt update && apt install -yq \
     automake \
     ccache \
     clang-format-6.0 \
+    clang-format-8 \
     g++ \
     gdb \
     lcov \

--- a/dockerfiles/Dockerfile.sdl_build.u18.04.git
+++ b/dockerfiles/Dockerfile.sdl_build.u18.04.git
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -yq \
     wget \
     curl \
     openssh-server \
-    clang-format-6.0 \
+    clang-format-8 \
     libssl-dev libudev-dev
 
 RUN sed -i 's|session required pam_loginuid.so|session optional pam_loginuid.so|g' /etc/pam.d/sshd

--- a/dockerfiles/Dockerfile.sdl_build.u18.04.git
+++ b/dockerfiles/Dockerfile.sdl_build.u18.04.git
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -yq \
     curl \
     openssh-server \
     clang-format-6.0 \
+    clang-format-8 \
     libssl-dev libudev-dev
 
 RUN sed -i 's|session required pam_loginuid.so|session optional pam_loginuid.so|g' /etc/pam.d/sshd

--- a/dockerfiles/Dockerfile.sdl_build.u20.04
+++ b/dockerfiles/Dockerfile.sdl_build.u20.04
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get -q -y install qt5-default libqt5websockets5-dev li
 
 # SDL build dependencies
 RUN apt-get update && apt-get -q -y install cmake libssl-dev libusb-1.0-0-dev \
-  libudev-dev libsqlite3-dev libbluetooth-dev clang-format-6.0
+  libudev-dev libsqlite3-dev libbluetooth-dev clang-format-8
 
 RUN apt-get update && apt-get -q -y install python3-pip python3-setuptools
 

--- a/dockerfiles/Dockerfile.sdl_build.u20.04
+++ b/dockerfiles/Dockerfile.sdl_build.u20.04
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get -q -y install qt5-default libqt5websockets5-dev li
 
 # SDL build dependencies
 RUN apt-get update && apt-get -q -y install cmake libssl-dev libusb-1.0-0-dev \
-  libudev-dev libsqlite3-dev libbluetooth-dev clang-format-6.0
+  libudev-dev libsqlite3-dev libbluetooth-dev clang-format-6.0 clang-format-8
 
 RUN apt-get update && apt-get -q -y install python3-pip python3-setuptools
 


### PR DESCRIPTION
Updating clang-format from version 6.0 to version 8.

These changes are based on the following issue:
https://adc.luxoft.com/jira/browse/FORDTCN-12271